### PR TITLE
不足したライブラリの追加と必要なライブラリをrequirements.txtで管理するように修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai==1.58.1
+opencv-python==4.10.0.84
+python-dotenv==1.0.1
+streamlit==1.41.1
+tiktoken==0.8.0


### PR DESCRIPTION
- ライブラリ`tiktoken`が足りていなかったので追加しました。
- また、Pythonのライブラリは`requirements.txt`で管理すると良いので、`requirements.txt`に出力しました。

[参照](https://nikkie-ftnext.hatenablog.com/entry/various-file-names-of-pip-freeze#requirementstxt%E3%81%AF%E6%89%8B%E3%81%A7%E4%BD%9C%E3%82%8B)